### PR TITLE
Remove call to localeCompare

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,7 @@ const initFileCentralDirTempl = () => {
 class Zipfile {
 	constructor(files, zipfile) {
 		this.index = 0;
-		files.sort((a, b) => {
-			return a.relativePath.localeCompare(b.relativePath);
-		});
+		files.sort();
 		this.fileObjects = files;
 		this.outputStream = fs.createWriteStream(zipfile);
 		this.fileheaderTempl = initFileHeaderTempl();


### PR DESCRIPTION
Remove `String.prototype.localeCompare` since it depends on how nodejs was built and the user’s default locale (see [Intl: Options for building Node.js](https://nodejs.org/api/intl.html#options-for-building-nodejs) which says that the behavior of `localeCompare` depends on the `--with-intl` `configure` flag). Instead, just use the default `sort` by code unit in the string ([`Array.prototype.sort`](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.sort) uses [abstract operation CompareArrayElements](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-comparearrayelements), which uses [abstract operation IsLessThan](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islessthan), which simply compares corresponding “numeric value of the code unit” of 2 Strings)